### PR TITLE
Add patch for axel.

### DIFF
--- a/net/axel/Portfile
+++ b/net/axel/Portfile
@@ -1,0 +1,38 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        axel-download-accelerator axel 2.13.1
+categories          net www
+platforms           darwin
+maintainers         nomaintainer
+license             {GPL-2+ OpenSSLException}
+
+description         A light Unix download accelerator
+
+long_description    Axel does the same thing any other accelerator does: \
+                    it opens more than one HTTP/FTP connection per download and \
+                    each connection transfers its own, separate, part of the file. \
+                    It may sound weird, but it works very well in practice.
+
+checksums           rmd160  da91494471f039818b93bff76327a67c12f099bb \
+                    sha256  e22dce8c03ad64357cbebf54f7ea76dcc7de5b707db66a4cea56c87ae6c9c079
+depends_lib         port:gettext \
+                    path:lib/libssl.dylib:openssl
+
+use_autoreconf      yes
+autoreconf.cmd      ./autogen.sh
+
+depends_build       port:autoconf \
+                    port:automake \
+                    port:libtool
+
+configure.cflags-append -std=c99
+
+post-destroot {
+    # https://trac.macports.org/ticket/47688
+    xinstall -d ${destroot}${prefix}/share/doc
+
+    copy ${worksrcpath}/doc ${destroot}${prefix}/share/doc/${subport}
+}


### PR DESCRIPTION
There are several issues in current Portfile that people don't notice the problem. Because it download binary directly.

1. wrong hash value.
2. wrong source file location
3. wrong source file name
4. no std=c99 cflag for old gcc.