### PR TITLE
openal-soft: bump to 1.19.1

### DIFF
--- a/audio/openal-soft/Portfile
+++ b/audio/openal-soft/Portfile
@@ -1,11 +1,17 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
-PortGroup               cmake 1.0
+PortGroup               cmake 1.1
+if {[variant_isset gui]} {
+PortGroup               qt5 1.0
+}
+PortGroup				legacysupport 1.1
+
+# Availability.h
+legacysupport.newest_darwin_requires_legacy 8
 
 name                    openal-soft
-version                 1.15.1
-revision                2
+version                 1.19.1
 categories              audio devel
 platforms               darwin
 maintainers             {ryandesign @ryandesign} openmaintainer
@@ -26,20 +32,64 @@ long_description        OpenAL Soft is a ${description}. It's forked from the \
                         facilitates streaming audio, multi-channel buffers, \
                         and audio capture.
 
-homepage                http://openal-soft.org
+homepage                https://openal-soft.org
 master_sites            ${homepage}/openal-releases/
 use_bzip2               yes
 
-checksums               rmd160  6c04d117712bb20ea9670e143a29b0ca738b6040 \
-                        sha256  0e29a162f0841ccb4135ce76e92e8a704589b680a85eddf76f898de5236eb056 \
-                        size    253006
+checksums           	rmd160  321998692c62088edad653806a7dd3b368bce9e7 \
+                    	sha256  5c2f87ff5188b95e0dc4769719a9d89ce435b8322b4478b95dd4b427fe84b2e9 \
+                    	size    577310
 
 depends_build-append    port:pkgconfig
 
-depends_lib-append      port:portaudio \
-                        port:pulseaudio
+compiler.cxx_standard   2011
 
-configure.args-append   -DEXAMPLES=OFF
+patchfiles				patch-Alc_backends_coreaudio.c-legacy-coreaudio.diff
+
+configure.args-append   -DALSOFT_EXAMPLES=OFF \
+                        -DALSOFT_TESTS=OFF \
+                        -DALSOFT_UTILS=ON \
+                        -DALSOFT_NO_CONFIG_UTIL=ON \
+                        -DALSOFT_REQUIRE_JACK=OFF \
+                        -DALSOFT_BACKEND_JACK=OFF \
+                        -DALSOFT_REQUIRE_PORTAUDIO=OFF \
+                        -DALSOFT_BACKEND_PORTAUDIO=OFF \
+                        -DALSOFT_REQUIRE_PULSEAUDIO=OFF \
+                        -DALSOFT_BACKEND_PULSEAUDIO=OFF \
+                        -DALSOFT_REQUIRE_SDL2=OFF \
+                        -DALSOFT_BACKEND_SDL2=OFF
+
+variant gui description {Enable alsoft-config GUI (requires Qt)} {
+    configure.args-replace  -DALSOFT_NO_CONFIG_UTIL=ON -DALSOFT_NO_CONFIG_UTIL=OFF
+}
+
+variant jack description {Enable JACK backend} {
+    depends_lib-append  port:jack
+    configure.args-replace  -DALSOFT_REQUIRE_JACK=OFF -DALSOFT_REQUIRE_JACK=ON \
+                            -DALSOFT_BACKEND_JACK=OFF -DALSOFT_BACKEND_JACK=ON
+}
+
+variant portaudio description {Enable PortAudio backend} {
+    depends_lib-append  port:portaudio
+    configure.args-replace  -DALSOFT_REQUIRE_PORTAUDIO=OFF -DALSOFT_REQUIRE_PORTAUDIO=ON \
+                            -DALSOFT_BACKEND_PORTAUDIO=OFF -DALSOFT_BACKEND_PORTAUDIO=ON
+}
+
+variant pulseaudio description {Enable PulseAudio backend} {
+    depends_lib-append  port:pulseaudio
+    configure.args-replace  -DALSOFT_REQUIRE_PULSEAUDIO=OFF -DALSOFT_REQUIRE_PULSEAUDIO=ON \
+                            -DALSOFT_BACKEND_PULSEAUDIO=OFF -DALSOFT_BACKEND_PULSEAUDIO=ON
+}
+
+variant sdl2 description {Enable SDL2 backend} {
+    depends_lib-append  port:libsdl2
+    configure.args-replace  -DALSOFT_REQUIRE_SDL2=OFF -DALSOFT_REQUIRE_SDL2=ON \
+                            -DALSOFT_BACKEND_SDL2=OFF -DALSOFT_BACKEND_SDL2=ON
+}
+
+variant tests description {Install test programs} {
+    configure.args-replace  -DALSOFT_TESTS=OFF -DALSOFT_TESTS=ON
+}
 
 livecheck.type          regex
 livecheck.regex         /${name}-(\[0-9.\]+)${extract.suffix}

--- a/audio/openal-soft/files/patch-Alc_backends_coreaudio.c-legacy-coreaudio.diff
+++ b/audio/openal-soft/files/patch-Alc_backends_coreaudio.c-legacy-coreaudio.diff
@@ -1,0 +1,148 @@
+--- Alc/backends/coreaudio.c.old	2018-10-11 23:05:31.000000000 +0100
++++ Alc/backends/coreaudio.c	2021-08-29 19:16:40.000000000 +0100
+@@ -31,9 +31,15 @@
+ #include <unistd.h>
+ #include <AudioUnit/AudioUnit.h>
+ #include <AudioToolbox/AudioToolbox.h>
++#include <Availability.h>
+ 
+ #include "backends/base.h"
+ 
++#ifndef LEGACY_COREAUDIO
++#if (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED < 1060)
++#define LEGACY_COREAUDIO 1
++#endif
++#endif
+ 
+ static const ALCchar ca_device[] = "CoreAudio Default";
+ 
+@@ -75,7 +81,11 @@
+ static void ALCcoreAudioPlayback_Destruct(ALCcoreAudioPlayback *self)
+ {
+     AudioUnitUninitialize(self->audioUnit);
++#if LEGACY_COREAUDIO
++    CloseComponent(self->audioUnit);
++#else
+     AudioComponentInstanceDispose(self->audioUnit);
++#endif
+ 
+     ALCbackend_Destruct(STATIC_CAST(ALCbackend, self));
+ }
+@@ -100,8 +110,13 @@
+ static ALCenum ALCcoreAudioPlayback_open(ALCcoreAudioPlayback *self, const ALCchar *name)
+ {
+     ALCdevice *device = STATIC_CAST(ALCbackend,self)->mDevice;
++#if LEGACY_COREAUDIO
++    ComponentDescription desc;
++    Component comp;
++#else
+     AudioComponentDescription desc;
+     AudioComponent comp;
++#endif
+     OSStatus err;
+ 
+     if(!name)
+@@ -120,14 +135,22 @@
+     desc.componentFlags = 0;
+     desc.componentFlagsMask = 0;
+ 
++#if LEGACY_COREAUDIO
++    comp = FindNextComponent(NULL, &desc);
++#else
+     comp = AudioComponentFindNext(NULL, &desc);
++#endif
+     if(comp == NULL)
+     {
+         ERR("AudioComponentFindNext failed\n");
+         return ALC_INVALID_VALUE;
+     }
+ 
++#if LEGACY_COREAUDIO
++    err = OpenAComponent(comp, &self->audioUnit);
++#else
+     err = AudioComponentInstanceNew(comp, &self->audioUnit);
++#endif
+     if(err != noErr)
+     {
+         ERR("AudioComponentInstanceNew failed\n");
+@@ -139,7 +162,11 @@
+     if(err != noErr)
+     {
+         ERR("AudioUnitInitialize failed\n");
++#if LEGACY_COREAUDIO
++        CloseComponent(self->audioUnit);
++#else
+         AudioComponentInstanceDispose(self->audioUnit);
++#endif
+         return ALC_INVALID_VALUE;
+     }
+ 
+@@ -397,7 +424,11 @@
+     self->audioConverter = NULL;
+ 
+     if(self->audioUnit)
++#if LEGACY_COREAUDIO
++        CloseComponent(self->audioUnit);
++#else
+         AudioComponentInstanceDispose(self->audioUnit);
++#endif
+     self->audioUnit = 0;
+ 
+     ALCbackend_Destruct(STATIC_CAST(ALCbackend, self));
+@@ -453,12 +484,20 @@
+     AudioStreamBasicDescription hardwareFormat;   // The hardware format
+     AudioStreamBasicDescription outputFormat;     // The AudioUnit output format
+     AURenderCallbackStruct input;
++#if LEGACY_COREAUDIO
++    ComponentDescription desc;
++#else
+     AudioComponentDescription desc;
++#endif
+     UInt32 outputFrameCount;
+     UInt32 propertySize;
+     AudioObjectPropertyAddress propertyAddress;
+     UInt32 enableIO;
++#if LEGACY_COREAUDIO
++    Component comp;
++#else
+     AudioComponent comp;
++#endif
+     OSStatus err;
+ 
+     if(!name)
+@@ -477,7 +516,11 @@
+     desc.componentFlagsMask = 0;
+ 
+     // Search for component with given description
++#if LEGACY_COREAUDIO
++    comp = FindNextComponent(NULL, &desc);
++#else
+     comp = AudioComponentFindNext(NULL, &desc);
++#endif
+     if(comp == NULL)
+     {
+         ERR("AudioComponentFindNext failed\n");
+@@ -485,7 +528,11 @@
+     }
+ 
+     // Open the component
++#if LEGACY_COREAUDIO
++    err = OpenAComponent(comp, &self->audioUnit);
++#else
+     err = AudioComponentInstanceNew(comp, &self->audioUnit);
++#endif
+     if(err != noErr)
+     {
+         ERR("AudioComponentInstanceNew failed\n");
+@@ -688,7 +735,11 @@
+         AudioConverterDispose(self->audioConverter);
+     self->audioConverter = NULL;
+     if(self->audioUnit)
++#if LEGACY_COREAUDIO
++        CloseComponent(self->audioUnit);
++#else
+         AudioComponentInstanceDispose(self->audioUnit);
++#endif
+     self->audioUnit = 0;
+ 
+     return ALC_INVALID_VALUE;


### PR DESCRIPTION
This seems to be the newest version of openal-soft that can be patched to build & run on Tiger/Leopard without significant effort due to newer releases relying on libdispatch for semaphores. Unfortunately, since version 1.19.1 was never officially available in MacPorts, it fails to download the source archive. (I'm guessing it can't grab it from the the official site either due to the system SSL libraries?)

I'm not sure of the best way to manage this, aside from hosting the archive somewhere else with a less restrictive SSL setup and changing the homepage in the Portfile but that's probably not a great idea from a long term maintainability standpoint. Any suggestions would be welcome!